### PR TITLE
Add parameters to update java and tomcat version at image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,40 @@
+# Based on quay.io/semoss/docker-r-python/docker-tomcat:cuda12.5
 #docker build . -t quay.io/semoss/docker-tomcat:cuda12.5
 
 ARG BASE_REGISTRY=quay.io
 ARG BASE_IMAGE=semoss/docker-r-python
 ARG BASE_TAG=cuda12.5
 
-ARG TOMCAT_HOME=/opt/apache-tomcat-9.0.102
-ARG JAVA_HOME=/usr/lib/jvm/zulu8
+# JAVA, JDK and TOMCAT default versions
+ARG AZUL_ZULU_VERSION=21.42.19
+ARG JAVA_HOME=/usr/lib/jvm/zulu21
+ARG JDK_VERSION=21.0.7
+ARG TOMCAT_VERSION=9.0.107
 ARG MAVEN_HOME=/opt/apache-maven-3.8.5
-#ARG LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
-FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as builder
+FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS builder
 
 LABEL maintainer="semoss@semoss.org"
 
-ARG TOMCAT_HOME
-ARG JAVA_HOME
+# Tomcat and Maven 
+ARG TOMCAT_VERSION
 ARG MAVEN_HOME
-#ARG LD_LIBRARY_PATH
+ARG TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 
-ENV TOMCAT_HOME=$TOMCAT_HOME
-ENV JAVA_HOME=$JAVA_HOME
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+# JAVA arguments
+ARG AZUL_ZULU_VERSION
+ARG JAVA_HOME
+ARG JDK_VERSION
+
+#JAVA env values for install_java.sh
+ENV AZUL_ZULU_VERSION=${AZUL_ZULU_VERSION}
+ENV JDK_VERSION=${JDK_VERSION}
+
+ENV TOMCAT_VERSION=${TOMCAT_VERSION}
+ENV TOMCAT_HOME=${TOMCAT_HOME}
+ENV JAVA_HOME=${JAVA_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 RUN printenv | grep -E '^(JAVA_HOME|TOMCAT_HOME|MAVEN_HOME|LD_LIBRARY_PATH|PATH)=' | awk '{print "export " $0}' >> /opt/set_env.env
 
@@ -35,12 +48,12 @@ RUN apt-get update \
 	&& chmod +x install_java.sh \
 	&& /bin/bash install_java.sh \
 	&& java -version \
-	&& wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.102/bin/apache-tomcat-9.0.102.tar.gz \
-	&& tar -zxvf apache-tomcat-9.0.*.tar.gz \
+	&& wget https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz \
+	&& tar -zxvf apache-tomcat-9.*.tar.gz \
 	&& mkdir $TOMCAT_HOME \
-	&& mv apache-tomcat-9.0.*/* $TOMCAT_HOME/ \
-	&& rm -r apache-tomcat-9.0.*/ \
-	&& rm apache-tomcat-9.0.*.tar.gz \
+	&& mv apache-tomcat-9.*/* $TOMCAT_HOME/ \
+	&& rm -r apache-tomcat-9.*/ \
+	&& rm apache-tomcat-9.*.tar.gz \
  	%% rm -rf $TOMCAT_HOME/webapps/* \
 	&& rm $TOMCAT_HOME/conf/server.xml \
 	&& rm $TOMCAT_HOME/conf/web.xml \
@@ -74,7 +87,6 @@ ENV TOMCAT_HOME=$TOMCAT_HOME
 ENV JAVA_HOME=$JAVA_HOME
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 #ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 
 COPY --from=builder / /
 WORKDIR $TOMCAT_HOME/webapps

--- a/install_java.sh
+++ b/install_java.sh
@@ -1,7 +1,22 @@
+#ORIGINAL
+# arch=$(uname -m)
+# if [[ $arch == x86_64* ]]; then
+#     echo "X64 Architecture"
+#     wget -O /tmp/zulujdk.tar.gz https://cdn.azul.com/zulu/bin/zulu8.78.0.19-ca-jdk8.0.412-linux_x64.tar.gz
+#     tar --extract --file /tmp/zulujdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+# elif  [[ $arch == arm* ]] || [[ $arch = aarch64 ]]; then
+#     echo "ARM Architecture"
+#     wget -O /tmp/zulujdk.tar.gz https://cdn.azul.com/zulu-embedded/bin/zulu8.76.0.17-ca-jdk8.0.402-linux_aarch64.tar.gz
+#     tar --extract --file /tmp/zulujdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+#     apt-get install -y openjfx
+# fi
+
+###################################################
+
 arch=$(uname -m)
 if [[ $arch == x86_64* ]]; then
     echo "X64 Architecture"
-    wget -O /tmp/zulujdk.tar.gz https://cdn.azul.com/zulu/bin/zulu8.78.0.19-ca-jdk8.0.412-linux_x64.tar.gz
+    wget -O /tmp/zulujdk.tar.gz https://cdn.azul.com/zulu/bin/zulu${AZUL_ZULU_VERSION}-ca-jdk${JDK_VERSION}-linux_x64.tar.gz
     tar --extract --file /tmp/zulujdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 elif  [[ $arch == arm* ]] || [[ $arch = aarch64 ]]; then
     echo "ARM Architecture"


### PR DESCRIPTION
## Description
This change will allow updating the tomcat and java version in one single place instead of updating the value in multiple places inside the Dockerfile and install_java.sh files 

## Changes Made
Added arguments to take the value of both the tomcat and java versions and pass them inside the Dockerfile and install_java.sh file. 
The arguments can be overwritten at build time by passing the arguments to the docker build command

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Change the java/tomcat version using docker build's "build-arg" flag:
```
    docker build --no-cache  --build-arg TOMCAT_VERSION=9.0.102 \
    --build-arg AZUL_ZULU_VERSION=21.42.19 \  
    -t quay.io/semoss/docker-tomcat:cuda12.5 -f Dockerfile .
```
2. Image will be built with the specified java and tomcat values
## Notes
<!-- Any further notes regarding changes -->